### PR TITLE
Fixes a speed bug in Lunar Lander

### DIFF
--- a/ntvao.cxx
+++ b/ntvao.cxx
@@ -385,7 +385,7 @@ void mos6502_apple1_store( uint16_t address )
             printf( "%c", ch );
             fflush( stdout );
         }
-        memory[ 0xd012 ] = 0;  // Indicate that the character has been consumed
+        memory[ 0xd012 ] = ch;  // Indicate that the character has been consumed
     }
 } //mos6502_apple1_store
 


### PR DESCRIPTION
Before this patch, Lunar Lander displays speed = "-+50 ft/s".
This is because the display routine of NTVAO messes with the Zero-Flag of the emulated CPU.
After the patch, the zero-flag is representive ot the written character just writtent, which typically is nonzero.